### PR TITLE
Add CMocka unit tests for several components

### DIFF
--- a/cmocka/Makefile
+++ b/cmocka/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-I../src/libstrongswan -I../src/libstrongswan/tests $(shell pkg-config --cflags cmocka) -include ../config.h
+LDFLAGS=-L../src/libstrongswan/.libs -lstrongswan -lpthread $(shell pkg-config --libs cmocka)
+
+TESTS=test_blocking_queue test_callback_cred test_cert_cache test_pkcs5 test_prf
+
+all: $(TESTS)
+
+%: %.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	rm -f $(TESTS)

--- a/cmocka/test_blocking_queue.c
+++ b/cmocka/test_blocking_queue.c
@@ -1,0 +1,45 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <library.h>
+#include <collections/blocking_queue.h>
+#include <stdlib.h>
+
+static void test_basic_enqueue_dequeue(void **state)
+{
+    (void)state;
+    blocking_queue_t *q = blocking_queue_create();
+    int a = 1, b = 2, c = 3;
+    q->enqueue(q, &a);
+    q->enqueue(q, &b);
+    q->enqueue(q, &c);
+    assert_ptr_equal(q->dequeue(q), &a);
+    assert_ptr_equal(q->dequeue(q), &b);
+    assert_ptr_equal(q->dequeue(q), &c);
+    q->destroy(q);
+}
+
+static void test_destroy_function(void **state)
+{
+    (void)state;
+    blocking_queue_t *q = blocking_queue_create();
+    int *a = malloc(sizeof(int));
+    int *b = malloc(sizeof(int));
+    q->enqueue(q, a);
+    q->enqueue(q, b);
+    q->destroy_function(q, free);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_basic_enqueue_dequeue),
+        cmocka_unit_test(test_destroy_function),
+    };
+    library_init(NULL, "cmocka");
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    library_deinit();
+    return ret;
+}

--- a/cmocka/test_callback_cred.c
+++ b/cmocka/test_callback_cred.c
@@ -1,0 +1,64 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <credentials/sets/callback_cred.h>
+#include <library.h>
+#include <credentials/keys/shared_key.h>
+#include <utils/chunk.h>
+#include <string.h>
+#include <stdlib.h>
+
+typedef struct {
+    const char **strings;
+    size_t count;
+    size_t index;
+} cb_data_t;
+
+static shared_key_t* shared_cb(void *data, shared_key_type_t type,
+                               identification_t *me, identification_t *other,
+                               id_match_t *match_me, id_match_t *match_other)
+{
+    cb_data_t *d = data;
+    (void)me; (void)other; (void)match_me; (void)match_other;
+    if (d->index >= d->count) {
+        return NULL;
+    }
+    char *s = strdup(d->strings[d->index++]);
+    return shared_key_create(type, chunk_from_str(s));
+}
+
+static void test_shared_enumerator(void **state)
+{
+    (void)state;
+    const char *vals[] = {"one", "two"};
+    cb_data_t data = { vals, 2, 0 };
+    callback_cred_t *cred = callback_cred_create_shared(shared_cb, &data);
+    enumerator_t *e = cred->set.create_shared_enumerator(&cred->set, SHARED_IKE,
+                                                         NULL, NULL);
+    shared_key_t *key;
+    assert_true(e->enumerate(e, &key, NULL, NULL));
+    assert_int_equal(key->get_type(key), SHARED_IKE);
+    assert_memory_equal(key->get_key(key).ptr, "one", 3);
+    key->destroy(key);
+
+    assert_true(e->enumerate(e, &key, NULL, NULL));
+    assert_memory_equal(key->get_key(key).ptr, "two", 3);
+    key->destroy(key);
+
+    assert_false(e->enumerate(e, &key, NULL, NULL));
+    e->destroy(e);
+    cred->destroy(cred);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_shared_enumerator),
+    };
+    library_init(NULL, "cmocka");
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    library_deinit();
+    return ret;
+}

--- a/cmocka/test_cert_cache.c
+++ b/cmocka/test_cert_cache.c
@@ -1,0 +1,129 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <credentials/sets/cert_cache.h>
+#include <library.h>
+#include <credentials/certificates/certificate.h>
+#include <utils/chunk.h>
+#include <stdlib.h>
+
+typedef struct stub_certificate_t stub_certificate_t;
+struct stub_certificate_t {
+    certificate_t public;
+    certificate_type_t type;
+    int ref;
+    bool issued_by_result;
+    int issued_by_calls;
+};
+
+METHOD(certificate_t, stub_get_type, certificate_type_t,
+       stub_certificate_t *this)
+{
+    return this->type;
+}
+
+METHOD(certificate_t, stub_equals, bool,
+       stub_certificate_t *this, certificate_t *other)
+{
+    return &this->public == other;
+}
+
+METHOD(certificate_t, stub_issued_by, bool,
+       stub_certificate_t *this, certificate_t *issuer,
+       signature_params_t **scheme)
+{
+    this->issued_by_calls++;
+    if (scheme) {
+        *scheme = NULL;
+    }
+    return this->issued_by_result;
+}
+
+METHOD(certificate_t, stub_get_ref, certificate_t*,
+       stub_certificate_t *this)
+{
+    this->ref++;
+    return &this->public;
+}
+
+METHOD(certificate_t, stub_destroy, void,
+       stub_certificate_t *this)
+{
+    if (--this->ref == 0) {
+        free(this);
+    }
+}
+
+/* unused methods */
+METHOD(certificate_t, stub_get_subject, identification_t*, stub_certificate_t *this) { return NULL; }
+METHOD(certificate_t, stub_has_subject, id_match_t, stub_certificate_t *this, identification_t *id) { return ID_MATCH_NONE; }
+METHOD(certificate_t, stub_get_issuer, identification_t*, stub_certificate_t *this) { return NULL; }
+METHOD(certificate_t, stub_has_issuer, id_match_t, stub_certificate_t *this, identification_t *id) { return ID_MATCH_NONE; }
+METHOD(certificate_t, stub_get_public_key, public_key_t*, stub_certificate_t *this) { return NULL; }
+METHOD(certificate_t, stub_get_validity, bool, stub_certificate_t *this, time_t *when, time_t *nb, time_t *na) { return TRUE; }
+METHOD(certificate_t, stub_get_encoding, bool, stub_certificate_t *this, cred_encoding_type_t type, chunk_t *enc) { return FALSE; }
+
+static stub_certificate_t *stub_certificate_create(certificate_type_t type, bool result)
+{
+    stub_certificate_t *this;
+    INIT(this,
+        .public = {
+            .get_type = _stub_get_type,
+            .get_subject = _stub_get_subject,
+            .has_subject = _stub_has_subject,
+            .get_issuer = _stub_get_issuer,
+            .has_issuer = _stub_has_issuer,
+            .issued_by = _stub_issued_by,
+            .get_public_key = _stub_get_public_key,
+            .get_validity = _stub_get_validity,
+            .get_encoding = _stub_get_encoding,
+            .equals = _stub_equals,
+            .get_ref = _stub_get_ref,
+            .destroy = _stub_destroy,
+        },
+        .type = type,
+        .ref = 1,
+        .issued_by_result = result,
+        .issued_by_calls = 0,
+    );
+    return this;
+}
+
+static void test_cert_cache_basic(void **state)
+{
+    (void)state;
+    cert_cache_t *cache = cert_cache_create();
+    stub_certificate_t *subject = stub_certificate_create(CERT_X509, true);
+    stub_certificate_t *issuer = stub_certificate_create(CERT_X509, true);
+
+    assert_true(cache->issued_by(cache, &subject->public, &issuer->public, NULL));
+    assert_int_equal(subject->issued_by_calls, 1);
+
+    assert_true(cache->issued_by(cache, &subject->public, &issuer->public, NULL));
+    assert_int_equal(subject->issued_by_calls, 1);
+
+    enumerator_t *e = cache->set.create_cert_enumerator(&cache->set, CERT_ANY, KEY_ANY, NULL, false);
+    certificate_t *cert;
+    assert_true(e->enumerate(e, &cert));
+    assert_ptr_equal(cert, &subject->public);
+    assert_false(e->enumerate(e, &cert));
+    e->destroy(e);
+
+    cache->flush(cache, CERT_ANY);
+    cache->destroy(cache);
+    subject->public.destroy(&subject->public);
+    issuer->public.destroy(&issuer->public);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_cert_cache_basic),
+    };
+    library_init(NULL, "cmocka");
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    library_deinit();
+    return ret;
+}

--- a/cmocka/test_pkcs5.c
+++ b/cmocka/test_pkcs5.c
@@ -1,0 +1,28 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <crypto/pkcs5.h>
+#include <asn1/asn1.h>
+#include <library.h>
+#include <asn1/oid.h>
+
+static void test_pkcs5_create_destroy(void **state)
+{
+    chunk_t alg = asn1_algorithmIdentifier(OID_MD5);
+    pkcs5_t *pkcs5 = pkcs5_from_algorithmIdentifier(alg, 0);
+    assert_null(pkcs5);
+    chunk_free(&alg);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_pkcs5_create_destroy),
+    };
+    library_init(NULL, "cmocka");
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    library_deinit();
+    return ret;
+}

--- a/cmocka/test_prf.c
+++ b/cmocka/test_prf.c
@@ -1,0 +1,29 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <crypto/prfs/prf.h>
+#include <library.h>
+#include <asn1/oid.h>
+
+static void test_pseudo_random_function_from_oid(void **state)
+{
+    (void)state;
+    assert_int_equal(pseudo_random_function_from_oid(OID_HMAC_SHA1), PRF_HMAC_SHA1);
+    assert_int_equal(pseudo_random_function_from_oid(OID_HMAC_SHA256), PRF_HMAC_SHA2_256);
+    assert_int_equal(pseudo_random_function_from_oid(OID_HMAC_SHA384), PRF_HMAC_SHA2_384);
+    assert_int_equal(pseudo_random_function_from_oid(OID_HMAC_SHA512), PRF_HMAC_SHA2_512);
+    assert_int_equal(pseudo_random_function_from_oid(OID_MD5), PRF_UNDEFINED);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_pseudo_random_function_from_oid),
+    };
+    library_init(NULL, "cmocka");
+    int ret = cmocka_run_group_tests(tests, NULL, NULL);
+    library_deinit();
+    return ret;
+}


### PR DESCRIPTION
## Summary
- add new CMocka-based unit tests under `cmocka/`
- provide tests for blocking queues, callback credentials, certificate cache, PKCS5 parsing, and PRF OID mapping

## Testing
- `make` in `cmocka`
- `LD_LIBRARY_PATH=../src/libstrongswan/.libs ./test_blocking_queue`
- `LD_LIBRARY_PATH=../src/libstrongswan/.libs ./test_callback_cred`
- `LD_LIBRARY_PATH=../src/libstrongswan/.libs ./test_cert_cache`
- `LD_LIBRARY_PATH=../src/libstrongswan/.libs ./test_pkcs5`
- `LD_LIBRARY_PATH=../src/libstrongswan/.libs ./test_prf`